### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python code/ch10_intermezzo/game.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Run on Repl.it](https://repl.it/badge/github/Apress/make-your-own-python-text-adventure)](https://repl.it/github/Apress/make-your-own-python-text-adventure)
 # Apress Source Code
 
 This repository accompanies [*Make Your Own Python Text Adventure*](http://www.apress.com/9781484232309) by Phillip Johnson (Apress, 2018).


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MaddoxPealock/make-your-own-python-text-adventure-1).

Please consider adding the badge!